### PR TITLE
Update flake.lock

### DIFF
--- a/templates/basic/flake.lock
+++ b/templates/basic/flake.lock
@@ -246,7 +246,7 @@
     "php-active": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-7ISUiJjiPCu0yx/e+xcJMPskpDYl1bO9eum6cPkjnB8=",
+        "narHash": "sha256-20qIiLPpROWf6onLj1r7dMjt/VhUO8//fzYYt4KlPYQ=",
         "type": "file",
         "url": "https://www.php.net/releases/active"
       },


### PR DESCRIPTION
`nix build` is informing, that the expected hash does not match the received one. Therefore I've updated it inside the lock file. Now it's the same `php-active` hash from the root flake.lock file of this repository.

This PR

- [x]
- [ ]
- [ ]

Follows #.
Related to #.
Fixes #.
