### PR TITLE
Fix: welcomeText template path

### DIFF
--- a/src/imports/templates.nix
+++ b/src/imports/templates.nix
@@ -6,7 +6,7 @@
       basic = {
         path = ../../templates/basic;
         description = "A basic template for getting started with PHP development";
-        welcomeText = builtins.readFile ./templates/basic/README.md;
+        welcomeText = builtins.readFile ../../templates/basic/README.md;
       };
     };
   };


### PR DESCRIPTION
This PR fixes error message  `src/imports/templates/basic/README.md': No such file or directory` when using:
`nix flake init --template github:loophp/nix-shell#basic`